### PR TITLE
RDKBACCL-1005 : Booting up without ethwan cable, erouter0 interface is down after plugin

### DIFF
--- a/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
+++ b/meta-rdk-mtk-bpir4/recipes-ccsp/ccsp/ccsp-common-library.bbappend
@@ -59,6 +59,7 @@ do_install_append_class-target() {
    sed -i '/^After=CcspPandMSsp\.service$/d' ${D}${systemd_unitdir}/system/onewifi.service
    sed -i '$a [Install]\nWantedBy=multi-user.target' ${D}${systemd_unitdir}/system/onewifi.service
    fi
+   sed -i '/IsErouterRunningStatus/,/fi/ s/^/#/' ${D}/usr/ccsp/ccspPAMCPCheck.sh
 }
 
 


### PR DESCRIPTION
Reason for Change : erouter0 interface is down for Fast ethernet d-link models
Test Procedure : Boot up the kernel 6.6 without ethwan cable Wait for 100 secs and plugin the ethwan cable (through D-link), check erouter0 interface is up and ip
 Risks : None